### PR TITLE
Twitter doesn't respond to to non-https traffic anymore

### DIFF
--- a/libs/twitter/oauth_dance.py
+++ b/libs/twitter/oauth_dance.py
@@ -37,7 +37,7 @@ In the web browser window that opens please choose to Allow
 access. Copy the PIN number that appears on the next page and paste or
 type it here:
 """)
-    oauth_url = ('http://api.twitter.com/oauth/authorize?oauth_token=' +
+    oauth_url = ('https://api.twitter.com/oauth/authorize?oauth_token=' +
                  oauth_token)
     print("Opening: %s\n" % oauth_url)
     return oauth_url, oauth_token, oauth_token_secret


### PR DESCRIPTION
Since January 14th, 2014 - Twitter has started restricting all api.twitter.com traffic to HTTPs only (https://dev.twitter.com/discussions/24239)
